### PR TITLE
Change ternary output to bools from strings

### DIFF
--- a/packages/tiny-mobx-form/example/introduction.mdx
+++ b/packages/tiny-mobx-form/example/introduction.mdx
@@ -604,7 +604,7 @@ function Field({ name, showErrors }) {
         validationMessage={ showErrors && fields[name].hasErrors && fields[name].errors.join(' ')}
         isInvalid={showErrors && fields[name].hasErrors}
         onChange={update}
-        autoFocus={fields[name].isFocused ? "true": "false"}
+        autoFocus={fields[name].isFocused ? true: false}
         key={`${fields[name].name}-${fields[name].isFocused}`}
       />
     </div>


### PR DESCRIPTION
Currently, these outputs are shown as strings, which are automatically interpreted as truthy.