### PR TITLE
Change period in length validation docs to comma

### DIFF
--- a/packages/tiny-mobx-form/example/introduction.mdx
+++ b/packages/tiny-mobx-form/example/introduction.mdx
@@ -56,7 +56,7 @@ interface IFormSchema {
   name: string; // The name of the field (must be unique)
   label?: string; // The label of the field
   placeholder?: string; // The placeholder of the input
-  validation?: string; // The validation string ("required|length:2.10|letters")
+  validation?: string; // The validation string ("required|length:2,10|letters")
   initialValue?: string; // The initial value of the field
 }
 ```


### PR DESCRIPTION
The example given was this:   `validation?: string; // The validation string ("required|length:2.10|letters")`.
Where in reality it should be:   `validation?: string; // The validation string ("required|length:2,10|letters")`

Notice the comma between 2 and 10.